### PR TITLE
only enable zoom with mouse wheel when pressing 'control'

### DIFF
--- a/FilesForPublishedWebsites/website/scripts/DataWharf_2022_07_08/visualization.js
+++ b/FilesForPublishedWebsites/website/scripts/DataWharf_2022_07_08/visualization.js
@@ -30,7 +30,7 @@ function createGraph(container, nodes, edges, autoLayout, rerouteEdgesOnVertexMo
 
     // Enables Mouse Wheel zoom  see https://github.com/jgraph/mxgraph/issues/418
     mxEvent.addMouseWheelListener((evt, up) => {
-      if (mxEvent.isConsumed(evt)) {
+      if (mxEvent.isConsumed(evt) || !mxEvent.isControlDown(evt)) {
         return;
       }
     


### PR DESCRIPTION
Zoom with wheel will only be enabled if "control" is pressed at the same time.